### PR TITLE
Caracter de nova linha em falta

### DIFF
--- a/labs/lab02/README.md
+++ b/labs/lab02/README.md
@@ -39,7 +39,7 @@ O resultado deve ser impresso com o comando `printf("min: %f, max: %f\n", min, m
 (Média) Escreva um programa que calcule e imprima a média de `N` números reais dados pelo
 utilizador.  O programa deverá primeiro pedir ao utilizador um inteiro `N`, representando
 a quantidade de números que vão ser introduzidos. Os números reais devem ser representados
-pelo tipo `float`. O resultado deve ser impresso com o comando `printf("%.2f", media);`.
+pelo tipo `float`. O resultado deve ser impresso com o comando `printf("%.2f\n", media);`.
 
 # ex05
 


### PR DESCRIPTION
No ex04, no comando prinf fornecido falta um caracter de nova linha para estar de acordo com os scripts de teste.